### PR TITLE
Add embedded args

### DIFF
--- a/mir-ci/mir_ci/robot_libraries/WaylandHid.py
+++ b/mir-ci/mir_ci/robot_libraries/WaylandHid.py
@@ -51,6 +51,10 @@ class WaylandHid(VirtualPointer):
     @keyword
     async def get_absolute_from_proportional(self, x: float, y: float) -> Dict[str, float]:
         """Get the absolute position for the given output size proportions."""
+        assert 0 <= x <= 1, "x not in range 0..1"
+        assert 0 <= y <= 1, "y not in range 0..1"
+        assert self.output_width > 0, "Output width must be greater than 0"
+        assert self.output_height > 0, "Output height must be greater than 0"
         await self.connect()
         return {"x": x * self.output_width, "y": y * self.output_height}
 

--- a/mir-ci/mir_ci/robot_libraries/WaylandHid.py
+++ b/mir-ci/mir_ci/robot_libraries/WaylandHid.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from typing import Dict
 
 from mir_ci.virtual_pointer import Button, VirtualPointer
 from robot.api.deco import keyword, library
@@ -46,6 +47,12 @@ class WaylandHid(VirtualPointer):
         """Release a button (LEFT|RIGHT|MIDDLE) on the virtual pointer."""
         await self.connect()
         self.button(Button[button], False)
+
+    @keyword
+    async def get_absolute_from_proportional(self, x: float, y: float) -> Dict[str, float]:
+        """Get the absolute position for the given output size proportions."""
+        await self.connect()
+        return {"x": x * self.output_width, "y": y * self.output_height}
 
     async def connect(self):
         """Connect to the display."""

--- a/mir-ci/mir_ci/robot_resources/screencopy.resource
+++ b/mir-ci/mir_ci/robot_resources/screencopy.resource
@@ -18,75 +18,50 @@ Displace ${point} By ${displacement_x} And ${displacement_y}
     RETURN    ${point}
 
 Move Pointer To ${destination}
-    [Documentation]    Move the pointer to a point position or image template.
+    [Documentation]    Move the pointer to a position or image template.
     ...
     ...    If ${destination} is an image template, the corresponding position
     ...    will be that of the center of the first matching template region.
     ...
-    ...    Optional arguments:
-    ...    ${proportional}: if True, coordinates in ${destination} are
-    ...    considered as proportions to the output dimensions. This argument
-    ...    is ignored if ${destination} is an image template. Default is False.
-    ...
     ...    The return value is the pointer position after the move.
-    [Arguments]    ${proportional}=False
     IF    ${{isinstance($destination, str)}}
         ${regions}=    Screencopy.Match    ${destination}
         ${position}=    Get Center Of ${regions}[0]
     ELSE
-        IF    ${proportional} == True
-            ${position}=    WaylandHid.Get Absolute From Proportional    ${destination}[x]    ${destination}[y]
-        ELSE
-            ${position}=    Set Variable    ${destination}
-        END
+        ${position}=    Set Variable    ${destination}
     END
     WaylandHid.Move Pointer To Absolute    ${position}[x]    ${position}[y]
     RETURN    ${position}
 
-Walk Pointer From ${source} To ${destination}
-    [Documentation]    Move the pointer in incremental steps from a source
-    ...    point position or image template to a destination point position
-    ...    or image template.
+Move Pointer To Proportional ${position}
+    [Documentation]    Move the pointer to a position given as proportions to
+    ...    the size of the display output.
     ...
-    ...    If an image template is given as ${source} or ${destination}, the
-    ...    corresponding position will be that of the center of the first
-    ...    matching template region.
+    ...    The return value is the pointer position after the move.
+    WaylandHid.Move Pointer To Proportional    ${position}[x]    ${position}[y]
+    RETURN    ${position}
+
+Walk Pointer From ${start_position} To ${destination}
+    [Documentation]    Move the pointer in incremental steps from a start
+    ...    position to a destination position or image template.
+    ...
+    ...    If an image template is given as ${destination}, the corresponding
+    ...    position will be that of the center of the first matching template
+    ...    region.
     ...
     ...    Optional arguments:
     ...    ${steps}: number of steps. If <= 0, the pointer is moved in
     ...    increments of 16 pixels. Default is 0.
     ...    ${step_sleep}: time to sleep after each step, in seconds.
     ...    Default is 0.
-    ...    ${proportional_source}: if True, coordinates in ${source}
-    ...    are considered as proportions to the output dimensions. This
-    ...    argument is ignored if ${source} is an image template.
-    ...    Default is False.
-    ...    ${proportional_destination}: if True, coordinates in ${destination}
-    ...    are considered as proportions to the output dimensions. This
-    ...    argument is ignored if ${destination} is an image template.
-    ...    Default is False.
     ...
     ...    The return value is the pointer position after the walk.
-    [Arguments]    ${steps}=0    ${step_sleep}=0    ${proportional_source}=False    ${proportional_destination}=False
-    IF    ${{isinstance($source, str)}}
-        ${regions}=    Screencopy.Match    ${source}
-        ${start_position}=    Get Center Of ${regions}[0]
-    ELSE
-        IF    ${proportional_source} == True
-            ${start_position}=    WaylandHid.Get Absolute From Proportional    ${source}[x]    ${source}[y]
-        ELSE
-            ${start_position}=    Set Variable    ${source}
-        END
-    END
+    [Arguments]    ${steps}=0    ${step_sleep}=0
     IF    ${{isinstance($destination, str)}}
         ${regions}=    Screencopy.Match    ${destination}
         ${end_position}=    Get Center Of ${regions}[0]
     ELSE
-        IF    ${proportional_destination} == True
-            ${end_position}=    WaylandHid.Get Absolute From Proportional    ${destination}[x]    ${destination}[y]
-        ELSE
-            ${end_position}=    Set Variable    ${destination}
-        END
+        ${end_position}=    Set Variable    ${destination}
     END
     IF    ${steps} <= 0
         ${distance}=    Distance From ${start_position} To ${end_position}
@@ -99,6 +74,14 @@ Walk Pointer From ${source} To ${destination}
         WaylandHid.Move Pointer To Absolute    ${position}[x]    ${position}[y]
         Sleep    ${step_sleep}
     END
+    RETURN    ${end_position}
+
+Walk Pointer From ${start_position} To Proportional ${end_position}
+    [Documentation]    Same as `Walk Pointer From ... To ...`,
+    ...    but with a proportional position as destination.
+    [Arguments]    ${steps}=0    ${step_sleep}=0
+    ${end_position}=    WaylandHid.Get Absolute From Proportional    ${end_position}[x]    ${end_position}[y]
+    ${end_position}=    Walk Pointer From ${start_position} To ${end_position}    ${steps}    ${step_sleep}
     RETURN    ${end_position}
 
 Distance From ${point_a} To ${point_b}

--- a/mir-ci/mir_ci/robot_resources/screencopy.resource
+++ b/mir-ci/mir_ci/robot_resources/screencopy.resource
@@ -12,9 +12,9 @@ Get Center Of ${region}
     ...    {"x": (${region}[left] + ${region}[right]) / 2, "y": (${region}[top] + ${region}[bottom]) / 2}
     RETURN    ${point}
 
-Displace ${point} By ${displacement_x} And ${displacement_y}
+Displace ${point} By (${x}, ${y})
     [Documentation]    Shift a point by the specified displacements along the x and y axes.
-    ${point}=    Evaluate    {"x": ${point}[x] + ${displacement_x}, "y": ${point}[y] + ${displacement_y}}
+    ${point}=    Evaluate    {"x": ${point}[x] + ${x}, "y": ${point}[y] + ${y}}
     RETURN    ${point}
 
 Move Pointer To ${destination}

--- a/mir-ci/mir_ci/robot_resources/screencopy.resource
+++ b/mir-ci/mir_ci/robot_resources/screencopy.resource
@@ -6,36 +6,88 @@ Library             ../robot_libraries/WaylandHid.py
 
 
 *** Keywords ***
-Get Center
+Get Center Of ${region}
     [Documentation]    Get the center point of a region.
-    [Arguments]    ${region}
     ${point}=    Evaluate
-    ...    {"x": int((${region}[left] + ${region}[right]) / 2), "y": int((${region}[top] + ${region}[bottom]) / 2)}
+    ...    {"x": (${region}[left] + ${region}[right]) / 2, "y": (${region}[top] + ${region}[bottom]) / 2}
     RETURN    ${point}
 
-Displace
+Displace ${point} By ${displacement_x} And ${displacement_y}
     [Documentation]    Shift a point by the specified displacements along the x and y axes.
-    [Arguments]    ${point}    ${displacement_x}    ${displacement_y}
     ${point}=    Evaluate    {"x": ${point}[x] + ${displacement_x}, "y": ${point}[y] + ${displacement_y}}
     RETURN    ${point}
 
-Move Pointer To Template
-    [Documentation]    Move the pointer to the center of the first matching image template.
-    [Arguments]    ${template}
-    ${regions}=    Match    ${template}
-    ${center}=    Get Center    ${regions}[0]
-    Move Pointer To Absolute    ${center}[x]    ${center}[y]
-    RETURN    ${center}
+Move Pointer To ${destination}
+    [Documentation]    Move the pointer to a point position or image template.
+    ...
+    ...    If ${destination} is an image template, the corresponding position
+    ...    will be that of the center of the first matching template region.
+    ...
+    ...    Optional arguments:
+    ...    ${proportional}: if True, coordinates in ${destination} are
+    ...    considered as proportions to the output dimensions. This argument
+    ...    is ignored if ${destination} is an image template. Default is False.
+    ...
+    ...    The return value is the pointer position after the move.
+    [Arguments]    ${proportional}=False
+    IF    ${{isinstance($destination, str)}}
+        ${regions}=    Screencopy.Match    ${destination}
+        ${position}=    Get Center Of ${regions}[0]
+    ELSE
+        IF    ${proportional} == True
+            ${position}=    WaylandHid.Get Absolute From Proportional    ${destination}[x]    ${destination}[y]
+        ELSE
+            ${position}=    Set Variable    ${destination}
+        END
+    END
+    WaylandHid.Move Pointer To Absolute    ${position}[x]    ${position}[y]
+    RETURN    ${position}
 
-Walk Pointer From ${start_position} To Template
-    [Documentation]    Move the pointer in incremental steps from a start position
-    ...    to the center of the first matching image template.
-    ...    If ${steps} <= 0, the pointer is moved in increments of 16 pixels.
-    ...    ${step_sleep} is the time to sleep after each step, in seconds.
+Walk Pointer From ${source} To ${destination}
+    [Documentation]    Move the pointer in incremental steps from a source
+    ...    point position or image template to a destination point position
+    ...    or image template.
+    ...
+    ...    If an image template is given as ${source} or ${destination}, the
+    ...    corresponding position will be that of the center of the first
+    ...    matching template region.
+    ...
+    ...    Optional arguments:
+    ...    ${steps}: number of steps. If <= 0, the pointer is moved in
+    ...    increments of 16 pixels. Default is 0.
+    ...    ${step_sleep}: time to sleep after each step, in seconds.
+    ...    Default is 0.
+    ...    ${proportional_source}: if True, coordinates in ${source}
+    ...    are considered as proportions to the output dimensions. This
+    ...    argument is ignored if ${source} is an image template.
+    ...    Default is False.
+    ...    ${proportional_destination}: if True, coordinates in ${destination}
+    ...    are considered as proportions to the output dimensions. This
+    ...    argument is ignored if ${destination} is an image template.
+    ...    Default is False.
+    ...
     ...    The return value is the pointer position after the walk.
-    [Arguments]    ${template}    ${steps}=0    ${step_sleep}=0
-    ${regions}=    Match    ${template}
-    ${end_position}=    Get Center    ${regions}[0]
+    [Arguments]    ${steps}=0    ${step_sleep}=0    ${proportional_source}=False    ${proportional_destination}=False
+    IF    ${{isinstance($source, str)}}
+        ${regions}=    Screencopy.Match    ${source}
+        ${start_position}=    Get Center Of ${regions}[0]
+    ELSE
+        IF    ${proportional_source} == True
+            ${start_position}=    WaylandHid.Get Absolute From Proportional    ${source}[x]    ${source}[y]
+        ELSE
+            ${start_position}=    Set Variable    ${source}
+        END
+    END
+    IF    ${{isinstance($destination, str)}}
+        ${regions}=    Screencopy.Match    ${destination}
+        ${end_position}=    Get Center Of ${regions}[0]
+    ELSE
+        IF    ${proportional_destination} == True
+            ${end_position}=    WaylandHid.Get Absolute From Proportional    ${destination}[x]    ${destination}[y]
+        ELSE
+            ${end_position}=    Set Variable    ${destination}
+        END
+    END
     IF    ${steps} <= 0
         ${distance}=    Distance From ${start_position} To ${end_position}
         ${step_in_pixels}=    Evaluate    16
@@ -43,8 +95,8 @@ Walk Pointer From ${start_position} To Template
     END
     FOR    ${step}    IN RANGE    0    ${{${steps} + 1}}
         ${t}=    Evaluate    ${step}/${steps}
-        ${point}=    Lerp Between ${start_position} And ${end_position} With Parameter ${t}
-        Move Pointer To Absolute    ${point}[x]    ${point}[y]
+        ${position}=    Lerp Between ${start_position} And ${end_position} With Parameter ${t}
+        WaylandHid.Move Pointer To Absolute    ${position}[x]    ${position}[y]
         Sleep    ${step_sleep}
     END
     RETURN    ${end_position}

--- a/mir-ci/mir_ci/robot_resources/screencopy.resource
+++ b/mir-ci/mir_ci/robot_resources/screencopy.resource
@@ -20,8 +20,8 @@ Displace ${point} By ${displacement_x} And ${displacement_y}
 Move Pointer To ${destination}
     [Documentation]    Move the pointer to a position or image template.
     ...
-    ...    If ${destination} is an image template, the corresponding position
-    ...    will be that of the center of the first matching template region.
+    ...    When ${destination} is the path of an image template file, the pointer
+    ...    will move to the center of the first matching template region.
     ...
     ...    The return value is the pointer position after the move.
     IF    ${{isinstance($destination, str)}}
@@ -37,7 +37,11 @@ Move Pointer To Proportional ${position}
     [Documentation]    Move the pointer to a position given as proportions to
     ...    the size of the display output.
     ...
-    ...    The return value is the pointer position after the move.
+    ...    ${position} must be a point represented by floating-point x and y
+    ...    values in the range 0..1.
+    ...
+    ...    The return value is the pointer position after the move,
+    ...    in absolute coordinates.
     WaylandHid.Move Pointer To Proportional    ${position}[x]    ${position}[y]
     RETURN    ${position}
 
@@ -45,18 +49,18 @@ Walk Pointer From ${start_position} To ${destination}
     [Documentation]    Move the pointer in incremental steps from a start
     ...    position to a destination position or image template.
     ...
-    ...    If an image template is given as ${destination}, the corresponding
-    ...    position will be that of the center of the first matching template
-    ...    region.
+    ...    When ${destination} is the path of an image template file, the
+    ...    corresponding position will be that of the center of the first
+    ...    matching template region.
     ...
     ...    Optional arguments:
     ...    ${steps}: number of steps. If <= 0, the pointer is moved in
     ...    increments of 16 pixels. Default is 0.
-    ...    ${step_sleep}: time to sleep after each step, in seconds.
+    ...    ${delay}: time to sleep after each step, in seconds.
     ...    Default is 0.
     ...
     ...    The return value is the pointer position after the walk.
-    [Arguments]    ${steps}=0    ${step_sleep}=0
+    [Arguments]    ${steps}=0    ${delay}=0
     IF    ${{isinstance($destination, str)}}
         ${regions}=    Screencopy.Match    ${destination}
         ${end_position}=    Get Center Of ${regions}[0]
@@ -72,16 +76,16 @@ Walk Pointer From ${start_position} To ${destination}
         ${t}=    Evaluate    ${step}/${steps}
         ${position}=    Lerp Between ${start_position} And ${end_position} With Parameter ${t}
         WaylandHid.Move Pointer To Absolute    ${position}[x]    ${position}[y]
-        Sleep    ${step_sleep}
+        Sleep    ${delay}
     END
     RETURN    ${end_position}
 
 Walk Pointer From ${start_position} To Proportional ${end_position}
     [Documentation]    Same as `Walk Pointer From ... To ...`,
     ...    but with a proportional position as destination.
-    [Arguments]    ${steps}=0    ${step_sleep}=0
+    [Arguments]    ${steps}=0    ${delay}=0
     ${end_position}=    WaylandHid.Get Absolute From Proportional    ${end_position}[x]    ${end_position}[y]
-    ${end_position}=    Walk Pointer From ${start_position} To ${end_position}    ${steps}    ${step_sleep}
+    ${end_position}=    Walk Pointer From ${start_position} To ${end_position}    ${steps}    ${delay}
     RETURN    ${end_position}
 
 Distance From ${point_a} To ${point_b}

--- a/mir-ci/mir_ci/test_drag_and_drop.py
+++ b/mir-ci/mir_ci/test_drag_and_drop.py
@@ -86,9 +86,9 @@ class TestDragAndDrop:
         robot_test_case = dedent(
             """\
             Source and Destination Match
-                ${pos}=    Move Pointer To Template    ${SRC_TEMPLATE}
+                ${pos}=    Move Pointer To ${SRC_TEMPLATE}
                 Press LEFT Button
-                Walk Pointer From ${pos} To Template    ${DST_TEMPLATE}
+                Walk Pointer From ${pos} To ${DST_TEMPLATE}
                 Release LEFT Button
         """
         )
@@ -120,11 +120,11 @@ class TestDragAndDrop:
         robot_test_case = dedent(
             """\
             Source and Destination Mismatch
-                ${pos}=    Move Pointer To Template    ${SRC_TEMPLATE}
+                ${pos}=    Move Pointer To ${SRC_TEMPLATE}
                 Press LEFT Button
-                ${pos}=    Walk Pointer From ${pos} To Template    ${DST_TEMPLATE}
+                ${pos}=    Walk Pointer From ${pos} To ${DST_TEMPLATE}
                 Release LEFT Button
-                Walk Pointer From ${pos} To Template    ${END_TEMPLATE}
+                Walk Pointer From ${pos} To ${END_TEMPLATE}
         """
         )
 

--- a/mir-ci/mir_ci/virtual_pointer.py
+++ b/mir-ci/mir_ci/virtual_pointer.py
@@ -29,8 +29,8 @@ class VirtualPointer(WaylandClient):
         self.output_manager: Optional[ZxdgOutputManagerV1Proxy] = None
         self.wl_outputs: List[WlOutputProxy] = []
         self.xdg_outputs: List[ZxdgOutputV1Proxy] = []
-        self.output_width = 1000
-        self.output_height = 1000
+        self.output_width = 0
+        self.output_height = 0
 
     def registry_global(self, registry, id_num: int, iface_name: str, version: int) -> None:
         if iface_name == ZwlrVirtualPointerManagerV1.name:
@@ -60,6 +60,8 @@ class VirtualPointer(WaylandClient):
             self.output_height = height
 
     def move_to_absolute(self, x: float, y: float) -> None:
+        assert self.output_width > 0, "Output width must be greater than 0"
+        assert self.output_height > 0, "Output height must be greater than 0"
         assert x >= 0 and x <= self.output_width, "x not in range 0-" + str(self.output_width)
         assert y >= 0 and y <= self.output_height, "y not in range 0-" + str(self.output_height)
         assert self.pointer is not None, "No pointer"


### PR DESCRIPTION
Fixes #83.

Modified keywords:

`Move Pointer To ${destination}`, where `${destination}` can be either the name of an image template, or an xy-point.
`Walk Pointer From ${source} To ${destination}`, where `${source}` and `${destination}` can be the name of image templates, or points.

Examples:
```robot
# Move to (100, 200)
${p}=    Evaluate    {"x":100, "y":200}
Move Pointer To ${p}

# Move to the center of the first region where the template matches
Move Pointer To "template.png"
```

An optional argument, `${proportional}`, can be used to move to a position proportional to the dimensions of the output.
For instance, to move to the center of the output:
```robot
${p}=    Evaluate    {"x":0.5, "y":0.5}
Move Pointer To ${p}    proportional=True
```
or simply
```robot
Move Pointer To ${{{"x":0.5, "y":0.5}}}    proportional=True
```

Examples with `Walk Pointer`:
```robot
Walk Pointer From "template0.png" To "template1.png"
Walk Pointer From ${p} To "template.png"
Walk Pointer From "template.png" To ${p}
Walk Pointer From ${p0} To ${p1}
```

`Walk Pointer` has `proportional_source` and `proportional_destination` optional arguments:

```robot
${center}=          Evaluate    {"x":0.5, "y":0.5}
${bottom_right}=    Evaluate    {"x":1, "y":1}
Walk Pointer From ${center} To ${bottom_right}    proportional_source=True    proportional_destination=True
```

PS. The names `Move Pointer To Proportional` and `Move Pointer To Absolute` from `WaylandHid` may be shadowed by `Move Pointer`. A solution is to use underscores or the keyword's full name:
```robot
Move_Pointer_To_Proportional    ${p}[x]    ${p}[y]               # OK
WaylandHid.Move Pointer To Proportional    ${p}[x]    ${p}[y]    # OK
Move Pointer To Proportional    ${p}[x]    ${p}[y]               # Error: calls `Move Pointer To`
```