### PR TITLE
snaps: drop checkbox-mir-beta

### DIFF
--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -31,8 +31,7 @@ SOURCE_NAME = "mir"
 
 SNAPS = {
     "checkbox-mir": {
-        "beta": {"ppa": "rc", "recipe": "checkbox-mir-beta"},
-        "edge": {"ppa": "dev", "recipe": "checkbox-mir-edge"},
+        "edge": {"ppa": "release", "recipe": "checkbox-mir-edge"},
     },
     "confined-shell": {
         "edge": {"recipe": "confined-shell-edge"},


### PR DESCRIPTION
There's no point in it, the only thing this affected was the mir_demo_server staged in the snap, which is not used in automation.