### PR TITLE
tests: reorganize apps into servers and apps, rework the server fixture and add Miriway

### DIFF
--- a/mir-ci/mir_ci/conftest.py
+++ b/mir-ci/mir_ci/conftest.py
@@ -64,6 +64,7 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
         debs: Optional[tuple[str]] = spec.get("debs")
         snap: Optional[str] = spec.get("snap")
         channel: str = spec.get("channel", "latest/stable")
+        classic: bool = spec.get("classic", False)
         pip_pkgs: tuple[str, ...] = spec.get("pip_pkgs", ())
         app_type: Optional[app.AppType] = spec.get("app_type")
     elif isinstance(spec, str):
@@ -71,6 +72,7 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
         debs = None
         snap = spec
         channel = "latest/stable"
+        classic = False
         pip_pkgs = ()
         app_type = "snap"
     else:
@@ -100,7 +102,8 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
                 try:
                     subprocess.check_call(("snap", "list", snap), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 except subprocess.CalledProcessError:
-                    subprocess.check_call(("sudo", "snap", "install", snap, "--channel", channel))
+                    _classic = ("--classic",) if classic else ()
+                    subprocess.check_call(("sudo", "snap", "install", snap, "--channel", channel, *_classic))
                     if shutil.which(f"/snap/{snap}/current/bin/setup.sh"):
                         subprocess.check_call(("sudo", f"/snap/{snap}/current/bin/setup.sh"))
                     subprocess.call(

--- a/mir-ci/mir_ci/conftest.py
+++ b/mir-ci/mir_ci/conftest.py
@@ -10,14 +10,14 @@ from typing import Any, Generator, List, Mapping, Optional, Union
 import distro
 import pytest
 from deepmerge import conservative_merger
-from mir_ci.fixtures import servers
+from mir_ci.fixtures.servers import server_params
 from mir_ci.program import app
 
 RELEASE_PPA = "mir-team/release"
 RELEASE_PPA_ENTRY = f"https://ppa.launchpadcontent.net/{RELEASE_PPA}/ubuntu {distro.codename()}/main"
 APT_INSTALL = ("sudo", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "--yes")
 PIP = ("python3", "-m", "pip")
-DEP_FIXTURES = {"server", "deps"}  # these are all the fixtures changing their behavior on `--deps`
+DEP_FIXTURES = {"any_server", "deps"}  # these are all the fixtures changing their behavior on `--deps`
 
 
 def pytest_addoption(parser):
@@ -137,22 +137,12 @@ def ppa() -> None:
         warnings.warn("Skipping PPA setup due to missing tools.")
 
 
-@pytest.fixture(
-    scope="function",
-    params=(
-        servers.ubuntu_frame,
-        servers.mir_kiosk,
-        servers.confined_shell,
-        servers.mir_test_tools,
-        servers.mir_demo_server,
-    ),
-)
-def server(request: pytest.FixtureRequest) -> app.App:
+@pytest.fixture(scope="function", params=server_params())
+def any_server(request: pytest.FixtureRequest) -> app.App:
     """
-    Parameterizes the servers (ubuntu-frame, mir-kiosk, confined-shell, mir_demo_server),
-    or installs them if `--deps` is given on the command line.
+    Parameterizes all the servers, or installs them if `--deps` is given on the command line.
     """
-    # Have to evaluate the param ourselves, because you can't mark fixtures and so
+    # Have to realize the param ourselves, because you can't mark fixtures and so
     # the `.deps(…)` mark never registers.
     server = _deps_install(request, request.param().marks[0].kwargs)
     _deps_skip(request)

--- a/mir-ci/mir_ci/conftest.py
+++ b/mir-ci/mir_ci/conftest.py
@@ -10,7 +10,8 @@ from typing import Any, Generator, List, Mapping, Optional, Union
 import distro
 import pytest
 from deepmerge import conservative_merger
-from mir_ci.fixtures import apps
+from mir_ci.fixtures import servers
+from mir_ci.program import app
 
 RELEASE_PPA = "mir-team/release"
 RELEASE_PPA_ENTRY = f"https://ppa.launchpadcontent.net/{RELEASE_PPA}/ubuntu {distro.codename()}/main"
@@ -46,7 +47,7 @@ def _deps_skip(request: pytest.FixtureRequest) -> None:
             pytest.skip("dependency-only run")
 
 
-def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, Any]]) -> apps.App:
+def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, Any]]) -> app.App:
     """
     Install dependencies for the command spec provided. If `spec` is a string, it's assumed
     to be a snap and command name.
@@ -64,7 +65,7 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
         snap: Optional[str] = spec.get("snap")
         channel: str = spec.get("channel", "latest/stable")
         pip_pkgs: tuple[str, ...] = spec.get("pip_pkgs", ())
-        app_type: Optional[apps.AppType] = spec.get("app_type")
+        app_type: Optional[app.AppType] = spec.get("app_type")
     elif isinstance(spec, str):
         cmd = [spec]
         debs = None
@@ -119,7 +120,7 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
         if missing_pkgs:
             subprocess.check_call((*PIP, "install", *missing_pkgs))
 
-    return apps.App(cmd, app_type)
+    return app.App(cmd, app_type)
 
 
 @pytest.fixture(scope="session")
@@ -139,14 +140,14 @@ def ppa() -> None:
 @pytest.fixture(
     scope="function",
     params=(
-        apps.ubuntu_frame,
-        apps.mir_kiosk,
-        apps.confined_shell,
-        apps.mir_test_tools,
-        apps.mir_demo_server,
+        servers.ubuntu_frame,
+        servers.mir_kiosk,
+        servers.confined_shell,
+        servers.mir_test_tools,
+        servers.mir_demo_server,
     ),
 )
-def server(request: pytest.FixtureRequest) -> apps.App:
+def server(request: pytest.FixtureRequest) -> app.App:
     """
     Parameterizes the servers (ubuntu-frame, mir-kiosk, confined-shell, mir_demo_server),
     or installs them if `--deps` is given on the command line.
@@ -159,7 +160,7 @@ def server(request: pytest.FixtureRequest) -> apps.App:
 
 
 @pytest.fixture(scope="function")
-def deps(request: pytest.FixtureRequest) -> Optional[apps.App]:
+def deps(request: pytest.FixtureRequest) -> Optional[app.App]:
     """
     Ensures the dependencies are available, or installs them if `--deps` is given on the command line.
 

--- a/mir-ci/mir_ci/fixtures/__init__.py
+++ b/mir-ci/mir_ci/fixtures/__init__.py
@@ -10,6 +10,7 @@ def _dependency(
     app_type: AppType,
     snap: Optional[str] = None,
     channel: str = "latest/stable",
+    classic: bool = False,
     debs: Collection[str] = (),
     pip_pkgs: Collection[str] = (),
     marks: Union[pytest.MarkDecorator, Collection[Union[pytest.MarkDecorator, pytest.Mark]]] = (),
@@ -26,7 +27,9 @@ def _dependency(
     return pytest.param(
         App(ret, app_type),
         marks=(  # type: ignore
-            pytest.mark.deps(cmd=cmd, snap=snap, debs=debs, pip_pkgs=pip_pkgs, channel=channel, app_type=app_type),
+            pytest.mark.deps(
+                cmd=cmd, snap=snap, debs=debs, pip_pkgs=pip_pkgs, channel=channel, classic=classic, app_type=app_type
+            ),
             *marks,
         ),
         id=id,

--- a/mir-ci/mir_ci/fixtures/__init__.py
+++ b/mir-ci/mir_ci/fixtures/__init__.py
@@ -1,0 +1,49 @@
+from typing import Any, Collection, Optional, Union
+
+import pytest
+
+from ..program.app import App, AppType
+
+
+def _dependency(
+    cmd: Collection[str],
+    app_type: AppType,
+    snap: Optional[str] = None,
+    channel: str = "latest/stable",
+    debs: Collection[str] = (),
+    pip_pkgs: Collection[str] = (),
+    marks: Union[pytest.MarkDecorator, Collection[Union[pytest.MarkDecorator, pytest.Mark]]] = (),
+    id: Optional[str] = None,
+    extra: Any = None,
+):
+    if isinstance(marks, pytest.Mark):
+        marks = (marks,)
+
+    ret = cmd
+    if extra is not None:
+        ret = (ret, extra)
+
+    return pytest.param(
+        App(ret, app_type),
+        marks=(  # type: ignore
+            pytest.mark.deps(cmd=cmd, snap=snap, debs=debs, pip_pkgs=pip_pkgs, channel=channel, app_type=app_type),
+            *marks,
+        ),
+        id=id,
+    )
+
+
+def snap(snap: str, *args: str, cmd: Collection[str] = (), id=None, **kwargs):
+    return _dependency(cmd=cmd or (snap, *args), app_type="snap", snap=snap, id=id or snap, **kwargs)
+
+
+def deb(
+    deb: str, *args: str, cmd: Collection[str] = (), debs: Collection[str] = (), id: Optional[str] = None, **kwargs
+):
+    return _dependency(cmd=cmd or (deb, *args), app_type="deb", debs=debs or (deb,), id=id or deb, **kwargs)
+
+
+def pip(pkg: str, *args: str, cmd: Collection[str] = (), id: Optional[str] = None, **kwargs):
+    return _dependency(
+        pip_pkgs=(pkg,), app_type="pip", cmd=cmd or ("python3", "-m", pkg, *args), id=id or pkg, **kwargs
+    )

--- a/mir-ci/mir_ci/fixtures/apps.py
+++ b/mir-ci/mir_ci/fixtures/apps.py
@@ -1,55 +1,9 @@
-from typing import Any, Collection, Optional, Union
-
 import pytest
 
-from ..program.app import App, AppType
+from . import deb, snap
 
 
-def _dependency(
-    cmd: Collection[str],
-    app_type: AppType,
-    snap: Optional[str] = None,
-    channel: str = "latest/stable",
-    debs: Collection[str] = (),
-    pip_pkgs: Collection[str] = (),
-    marks: Union[pytest.MarkDecorator, Collection[Union[pytest.MarkDecorator, pytest.Mark]]] = (),
-    id: Optional[str] = None,
-    extra: Any = None,
-):
-    if isinstance(marks, pytest.Mark):
-        marks = (marks,)
-
-    ret = cmd
-    if extra is not None:
-        ret = (ret, extra)
-
-    return pytest.param(
-        App(ret, app_type),
-        marks=(  # type: ignore
-            pytest.mark.deps(cmd=cmd, snap=snap, debs=debs, pip_pkgs=pip_pkgs, channel=channel, app_type=app_type),
-            *marks,
-        ),
-        id=id,
-    )
-
-
-def snap(snap: str, *args: str, cmd: Collection[str] = (), id=None, **kwargs):
-    return _dependency(cmd=cmd or (snap, *args), app_type="snap", snap=snap, id=id or snap, **kwargs)
-
-
-def deb(
-    deb: str, *args: str, cmd: Collection[str] = (), debs: Collection[str] = (), id: Optional[str] = None, **kwargs
-):
-    return _dependency(cmd=cmd or (deb, *args), app_type="deb", debs=debs or (deb,), id=id or deb, **kwargs)
-
-
-def pip(pkg: str, *args: str, cmd: Collection[str] = (), id: Optional[str] = None, **kwargs):
-    return _dependency(
-        pip_pkgs=(pkg,), app_type="pip", cmd=cmd or ("python3", "-m", pkg, *args), id=id or pkg, **kwargs
-    )
-
-
-def qterminal(*args: str, debs: Collection[str] = ("qterminal", "qtwayland5"), marks=(), **kwargs):
+def qterminal(*args: str, debs=("qterminal", "qtwayland5"), marks=(), **kwargs):
     marks = (pytest.mark.xdg(XDG_CONFIG_HOME={"qterminal.org/qterminal.ini": "[General]\nAskOnExit=false"}), *marks)
     return deb("qterminal", *args, debs=debs, marks=marks, **kwargs)
 
@@ -58,25 +12,5 @@ def pluma(*args: str, **kwargs):
     return deb("pluma", *args, **kwargs)
 
 
-def wpe(*args: str, cmd: Collection[str] = (), **kwargs):
+def wpe(*args: str, cmd=(), **kwargs):
     return snap("wpe-webkit-mir-kiosk", cmd=cmd or ("wpe-webkit-mir-kiosk.cog", *args), **kwargs)
-
-
-def ubuntu_frame():
-    return snap("ubuntu-frame", channel="22/stable", id="ubuntu_frame")
-
-
-def mir_kiosk():
-    return snap("mir-kiosk", id="mir_kiosk")
-
-
-def confined_shell():
-    return snap("confined-shell", channel="edge", id="confined_shell")
-
-
-def mir_test_tools():
-    return snap("mir-test-tools", channel="22/beta", cmd=("mir-test-tools.demo-server",), id="mir_test_tools")
-
-
-def mir_demo_server():
-    return deb("mir_demo_server", debs=("mir-test-tools", "mir-graphics-drivers-desktop"), id="mir_demo_server")

--- a/mir-ci/mir_ci/fixtures/servers.py
+++ b/mir-ci/mir_ci/fixtures/servers.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from enum import Flag, auto
 from typing import Callable, Sequence
 
@@ -34,6 +35,18 @@ def server(arg: ServerCap | Server):
         return arg
 
 
+def server_params(caps: ServerCap = ServerCap.NONE) -> Generator[Server, None, None]:
+    """
+    Use this in fixture parametrization to select servers with the necessary capabilities
+    for the fixture in question.
+
+    >>> @pytest.fixture(params=server_params(ServerCap.DRAG_AND_DROP))
+    >>> def func(request) -> app.App:
+            return request.param()
+    """
+    return (v for k, v in _SERVERS if caps in k)
+
+
 def servers(caps: ServerCap = ServerCap.NONE) -> Sequence[app.App]:
     """
     Use this in test parametrization to select servers with the necessary capabilities for the
@@ -45,7 +58,7 @@ def servers(caps: ServerCap = ServerCap.NONE) -> Sequence[app.App]:
     """
     # This tuple has to be realized here, otherwise class-wide parametrization
     # will exhaust the generator on the first test function.
-    return tuple(v() for k, v in _SERVERS if caps in k)
+    return tuple(p() for p in server_params(caps))
 
 
 @server(ServerCap.ALL ^ ServerCap.FLOATING_WINDOWS)

--- a/mir-ci/mir_ci/fixtures/servers.py
+++ b/mir-ci/mir_ci/fixtures/servers.py
@@ -1,21 +1,73 @@
+from enum import Flag, auto
+from typing import Callable, Sequence
+
+from ..program import app
 from . import deb, snap
 
+Server = Callable[[], app.App]
 
+
+class ServerCap(Flag):
+    """
+    Server capabilities for test parametrization, see servers() documentation.
+    """
+
+    NONE = 0
+    FLOATING_WINDOWS = auto()
+    DRAG_AND_DROP = auto()
+    ALL = FLOATING_WINDOWS | DRAG_AND_DROP
+
+
+_SERVERS: set[tuple[ServerCap, Server]] = set()
+
+
+def server(arg: ServerCap | Server):
+    if isinstance(arg, ServerCap):
+
+        def _wrap(func):
+            _SERVERS.add((arg, func))
+            return func
+
+        return _wrap
+    else:
+        _SERVERS.add((ServerCap.ALL, arg))
+        return arg
+
+
+def servers(caps: ServerCap = ServerCap.NONE) -> Sequence[app.App]:
+    """
+    Use this in test parametrization to select servers with the necessary capabilities for the
+    test in question.
+
+    >>> @pytest.mark.parametrize("server", servers(ServerCap.FLOATING_WINDOWS))
+    >>> def test_func(server):
+            pass
+    """
+    # This tuple has to be realized here, otherwise class-wide parametrization
+    # will exhaust the generator on the first test function.
+    return tuple(v() for k, v in _SERVERS if caps in k)
+
+
+@server(ServerCap.ALL ^ ServerCap.FLOATING_WINDOWS)
 def ubuntu_frame():
     return snap("ubuntu-frame", channel="22/stable", id="ubuntu_frame")
 
 
+@server(ServerCap.ALL ^ (ServerCap.FLOATING_WINDOWS | ServerCap.DRAG_AND_DROP))
 def mir_kiosk():
     return snap("mir-kiosk", id="mir_kiosk")
 
 
+@server
 def confined_shell():
     return snap("confined-shell", channel="edge", id="confined_shell")
 
 
+@server
 def mir_test_tools():
     return snap("mir-test-tools", channel="22/beta", cmd=("mir-test-tools.demo-server",), id="mir_test_tools")
 
 
+@server
 def mir_demo_server():
     return deb("mir_demo_server", debs=("mir-test-tools", "mir-graphics-drivers-desktop"), id="mir_demo_server")

--- a/mir-ci/mir_ci/fixtures/servers.py
+++ b/mir-ci/mir_ci/fixtures/servers.py
@@ -1,0 +1,21 @@
+from . import deb, snap
+
+
+def ubuntu_frame():
+    return snap("ubuntu-frame", channel="22/stable", id="ubuntu_frame")
+
+
+def mir_kiosk():
+    return snap("mir-kiosk", id="mir_kiosk")
+
+
+def confined_shell():
+    return snap("confined-shell", channel="edge", id="confined_shell")
+
+
+def mir_test_tools():
+    return snap("mir-test-tools", channel="22/beta", cmd=("mir-test-tools.demo-server",), id="mir_test_tools")
+
+
+def mir_demo_server():
+    return deb("mir_demo_server", debs=("mir-test-tools", "mir-graphics-drivers-desktop"), id="mir_demo_server")

--- a/mir-ci/mir_ci/fixtures/servers.py
+++ b/mir-ci/mir_ci/fixtures/servers.py
@@ -16,7 +16,8 @@ class ServerCap(Flag):
     NONE = 0
     FLOATING_WINDOWS = auto()
     DRAG_AND_DROP = auto()
-    ALL = FLOATING_WINDOWS | DRAG_AND_DROP
+    DISPLAY_CONFIG = auto()
+    ALL = FLOATING_WINDOWS | DRAG_AND_DROP | DISPLAY_CONFIG
 
 
 _SERVERS: set[tuple[ServerCap, Server]] = set()
@@ -61,22 +62,22 @@ def servers(caps: ServerCap = ServerCap.NONE) -> Sequence[app.App]:
     return tuple(p() for p in server_params(caps))
 
 
-@server(ServerCap.ALL ^ ServerCap.FLOATING_WINDOWS)
+@server(ServerCap.ALL ^ (ServerCap.FLOATING_WINDOWS | ServerCap.DISPLAY_CONFIG))
 def ubuntu_frame():
     return snap("ubuntu-frame", channel="22/stable", id="ubuntu_frame")
 
 
-@server(ServerCap.ALL ^ (ServerCap.FLOATING_WINDOWS | ServerCap.DRAG_AND_DROP))
+@server(ServerCap.ALL ^ (ServerCap.FLOATING_WINDOWS | ServerCap.DRAG_AND_DROP | ServerCap.DISPLAY_CONFIG))
 def mir_kiosk():
     return snap("mir-kiosk", id="mir_kiosk")
 
 
-@server
+@server(ServerCap.ALL ^ ServerCap.DISPLAY_CONFIG)
 def confined_shell():
     return snap("confined-shell", channel="edge", id="confined_shell")
 
 
-@server
+@server(ServerCap.ALL ^ ServerCap.DISPLAY_CONFIG)
 def mir_test_tools():
     return snap("mir-test-tools", channel="22/beta", cmd=("mir-test-tools.demo-server",), id="mir_test_tools")
 

--- a/mir-ci/mir_ci/fixtures/servers.py
+++ b/mir-ci/mir_ci/fixtures/servers.py
@@ -85,3 +85,8 @@ def mir_test_tools():
 @server
 def mir_demo_server():
     return deb("mir_demo_server", debs=("mir-test-tools", "mir-graphics-drivers-desktop"), id="mir_demo_server")
+
+
+@server
+def miriway():
+    return snap("miriway", channel="stable", classic=True)

--- a/mir-ci/mir_ci/tests/test_apps_can_run.py
+++ b/mir-ci/mir_ci/tests/test_apps_can_run.py
@@ -23,8 +23,8 @@ class TestAppsCanRun:
             apps.qterminal(),
         ],
     )
-    async def test_app_can_run(self, server, app, record_property) -> None:
-        server_instance = DisplayServer(server)
+    async def test_app_can_run(self, any_server, app, record_property) -> None:
+        server_instance = DisplayServer(any_server)
         program = server_instance.program(app)
         benchmarker = Benchmarker(OrderedDict(compositor=server_instance, client=program), poll_time_seconds=0.1)
         async with benchmarker:

--- a/mir-ci/mir_ci/tests/test_display_configuration.py
+++ b/mir-ci/mir_ci/tests/test_display_configuration.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, Mock
 
 import pytest
 from mir_ci import SLOWDOWN
-from mir_ci.fixtures import apps
+from mir_ci.fixtures import servers
 from mir_ci.program.display_server import DisplayServer
 from mir_ci.wayland.output_watcher import OutputWatcher
 
@@ -53,7 +53,7 @@ class DisplayServerStaticFile:
         # TODO: Test other servers. Frame-based servers use
         # a configuration file that is within the snap, so it
         # is unclear how to read/modify that file from the outside
-        apps.mir_demo_server(),
+        servers.mir_demo_server(),
     ],
 )
 @pytest.mark.deps(pip_pkgs=("pyyaml",))

--- a/mir-ci/mir_ci/tests/test_display_configuration.py
+++ b/mir-ci/mir_ci/tests/test_display_configuration.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, Mock
 
 import pytest
 from mir_ci import SLOWDOWN
-from mir_ci.fixtures import servers
+from mir_ci.fixtures.servers import ServerCap, servers
 from mir_ci.program.display_server import DisplayServer
 from mir_ci.wayland.output_watcher import OutputWatcher
 
@@ -47,19 +47,14 @@ class DisplayServerStaticFile:
             yaml.dump(content, file)
 
 
-@pytest.mark.parametrize(
-    "local_server",
-    [
-        # TODO: Test other servers. Frame-based servers use
-        # a configuration file that is within the snap, so it
-        # is unclear how to read/modify that file from the outside
-        servers.mir_demo_server(),
-    ],
-)
+# TODO: Test other servers. Frame-based servers use
+# a configuration file that is within the snap, so it
+# is unclear how to read/modify that file from the outside
+@pytest.mark.parametrize("server", servers(ServerCap.DISPLAY_CONFIG))
 @pytest.mark.deps(pip_pkgs=("pyyaml",))
 class TestDisplayConfiguration:
-    async def test_can_update_scale(self, local_server) -> None:
-        server = DisplayServerStaticFile(local_server)
+    async def test_can_update_scale(self, server) -> None:
+        server = DisplayServerStaticFile(server)
         on_scale = Mock()
         watcher = OutputWatcher(server.server.display_name, on_scale=on_scale)
 
@@ -78,8 +73,8 @@ class TestDisplayConfiguration:
 
         on_scale.assert_called_with(ANY, 2)
 
-    async def test_can_update_position(self, local_server) -> None:
-        server = DisplayServerStaticFile(local_server)
+    async def test_can_update_position(self, server) -> None:
+        server = DisplayServerStaticFile(server)
         on_geometry = Mock()
         watcher = OutputWatcher(server.server.display_name, on_geometry=on_geometry)
 

--- a/mir-ci/mir_ci/tests/test_drag_and_drop.py
+++ b/mir-ci/mir_ci/tests/test_drag_and_drop.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
-from mir_ci.fixtures import apps
+from mir_ci.fixtures import servers
+from mir_ci.program.app import App
 from mir_ci.program.display_server import DisplayServer
 from mir_ci.wayland.screencopy_tracker import ScreencopyTracker
 from mir_ci.wayland.virtual_pointer import VirtualPointer
@@ -49,11 +50,11 @@ ${{END_TEMPLATE}}    {TESTS_PATH}/robot/templates/drag_and_drop_end.png
 @pytest.mark.parametrize(
     "modern_server",
     [
-        apps.ubuntu_frame(),
-        # apps.mir_kiosk(), we need servers based on Mir 2.14 or later
-        apps.confined_shell(),
-        apps.mir_test_tools(),
-        apps.mir_demo_server(),
+        servers.ubuntu_frame(),
+        # servers.mir_kiosk(), we need servers based on Mir 2.14 or later
+        servers.confined_shell(),
+        servers.mir_test_tools(),
+        servers.mir_demo_server(),
     ],
 )
 @pytest.mark.deps(
@@ -81,7 +82,7 @@ class TestDragAndDrop:
     async def test_source_and_dest_match(self, modern_server, app, tmp_path) -> None:
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions
         server_instance = DisplayServer(modern_server, add_extensions=extensions)
-        program = server_instance.program(apps.App(app))
+        program = server_instance.program(App(app))
 
         robot_test_case = dedent(
             """\
@@ -97,7 +98,7 @@ class TestDragAndDrop:
             robot_file.write(
                 ROBOT_TEMPLATE.format(settings=ROBOT_SETTINGS, variables=ROBOT_VARIABLES, test_case=robot_test_case)
             )
-            robot = server_instance.program(apps.App(("robot", "-d", tmp_path, robot_file.name)))
+            robot = server_instance.program(App(("robot", "-d", tmp_path, robot_file.name)))
 
             async with server_instance, program, robot:
                 await robot.wait(60)
@@ -115,7 +116,7 @@ class TestDragAndDrop:
     async def test_source_and_dest_mismatch(self, modern_server, app, tmp_path) -> None:
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions
         server_instance = DisplayServer(modern_server, add_extensions=extensions)
-        program = server_instance.program(apps.App(app))
+        program = server_instance.program(App(app))
 
         robot_test_case = dedent(
             """\
@@ -132,7 +133,7 @@ class TestDragAndDrop:
             robot_file.write(
                 ROBOT_TEMPLATE.format(settings=ROBOT_SETTINGS, variables=ROBOT_VARIABLES, test_case=robot_test_case)
             )
-            robot = server_instance.program(apps.App(("robot", "-d", tmp_path, robot_file.name)))
+            robot = server_instance.program(App(("robot", "-d", tmp_path, robot_file.name)))
 
             async with server_instance, program, robot:
                 await robot.wait(60)

--- a/mir-ci/mir_ci/tests/test_drag_and_drop.py
+++ b/mir-ci/mir_ci/tests/test_drag_and_drop.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
-from mir_ci.fixtures import servers
+from mir_ci.fixtures.servers import ServerCap, servers
 from mir_ci.program.app import App
 from mir_ci.program.display_server import DisplayServer
 from mir_ci.wayland.screencopy_tracker import ScreencopyTracker
@@ -47,16 +47,7 @@ ${{END_TEMPLATE}}    {TESTS_PATH}/robot/templates/drag_and_drop_end.png
     },
 )
 @pytest.mark.env(GSETTINGS_BACKEND="keyfile")
-@pytest.mark.parametrize(
-    "modern_server",
-    [
-        servers.ubuntu_frame(),
-        # servers.mir_kiosk(), we need servers based on Mir 2.14 or later
-        servers.confined_shell(),
-        servers.mir_test_tools(),
-        servers.mir_demo_server(),
-    ],
-)
+@pytest.mark.parametrize("server", servers(ServerCap.DRAG_AND_DROP))
 @pytest.mark.deps(
     debs=(
         "libgirepository1.0-dev",
@@ -79,9 +70,9 @@ class TestDragAndDrop:
             ("python3", APP_PATH, "--source", "text", "--target", "text", "--expect", "text"),
         ],
     )
-    async def test_source_and_dest_match(self, modern_server, app, tmp_path) -> None:
+    async def test_source_and_dest_match(self, server, app, tmp_path) -> None:
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions
-        server_instance = DisplayServer(modern_server, add_extensions=extensions)
+        server_instance = DisplayServer(server, add_extensions=extensions)
         program = server_instance.program(App(app))
 
         robot_test_case = dedent(
@@ -113,9 +104,9 @@ class TestDragAndDrop:
             ("python3", "-u", APP_PATH, "--source", "text", "--target", "pixbuf", "--expect", "pixbuf"),
         ],
     )
-    async def test_source_and_dest_mismatch(self, modern_server, app, tmp_path) -> None:
+    async def test_source_and_dest_mismatch(self, server, app, tmp_path) -> None:
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions
-        server_instance = DisplayServer(modern_server, add_extensions=extensions)
+        server_instance = DisplayServer(server, add_extensions=extensions)
         program = server_instance.program(App(app))
 
         robot_test_case = dedent(

--- a/mir-ci/mir_ci/tests/test_screencopy_bandwidth.py
+++ b/mir-ci/mir_ci/tests/test_screencopy_bandwidth.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 from mir_ci import SLOWDOWN
-from mir_ci.fixtures import apps
+from mir_ci.fixtures import apps, servers
+from mir_ci.program.app import App
 from mir_ci.program.display_server import DisplayServer
 from mir_ci.wayland.screencopy_tracker import ScreencopyTracker
 from mir_ci.wayland.virtual_pointer import Button, VirtualPointer
@@ -40,7 +41,7 @@ class TestScreencopyBandwidth:
     async def test_active_app(self, record_property, server, app) -> None:
         server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
         tracker = ScreencopyTracker(server.display_name)
-        async with server as s, tracker, s.program(apps.App(app.command[0], app.app_type)) as p:
+        async with server as s, tracker, s.program(App(app.command[0], app.app_type)) as p:
             if app.command[1]:
                 await asyncio.wait_for(p.wait(timeout=app.command[1]), timeout=app.command[1] + 1)
             else:
@@ -73,9 +74,9 @@ class TestScreencopyBandwidth:
     @pytest.mark.parametrize(
         "local_server",
         [
-            apps.confined_shell(),
-            apps.mir_test_tools(),
-            apps.mir_demo_server(),
+            servers.confined_shell(),
+            servers.mir_test_tools(),
+            servers.mir_demo_server(),
         ],
     )
     async def test_app_dragged_around(self, record_property, local_server) -> None:
@@ -85,7 +86,7 @@ class TestScreencopyBandwidth:
         extensions = ScreencopyTracker.required_extensions + VirtualPointer.required_extensions
         app_path = Path(__file__).parent / "clients" / "maximizing_gtk_app.py"
         server = DisplayServer(local_server, add_extensions=extensions)
-        app = server.program(apps.App(("python3", str(app_path))))
+        app = server.program(App(("python3", str(app_path))))
         tracker = ScreencopyTracker(server.display_name)
         pointer = VirtualPointer(server.display_name)
         async with server, tracker, app, pointer:

--- a/mir-ci/mir_ci/tests/test_screencopy_bandwidth.py
+++ b/mir-ci/mir_ci/tests/test_screencopy_bandwidth.py
@@ -38,22 +38,22 @@ class TestScreencopyBandwidth:
             apps.snap("mir-kiosk-neverputt", extra=False),
         ],
     )
-    async def test_active_app(self, record_property, server, app) -> None:
-        server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
-        tracker = ScreencopyTracker(server.display_name)
-        async with server as s, tracker, s.program(App(app.command[0], app.app_type)) as p:
+    async def test_active_app(self, record_property, any_server, app) -> None:
+        any_server = DisplayServer(any_server, add_extensions=ScreencopyTracker.required_extensions)
+        tracker = ScreencopyTracker(any_server.display_name)
+        async with any_server as s, tracker, s.program(App(app.command[0], app.app_type)) as p:
             if app.command[1]:
                 await asyncio.wait_for(p.wait(timeout=app.command[1]), timeout=app.command[1] + 1)
             else:
                 await asyncio.sleep(long_wait_time)
-        _record_properties(record_property, server, tracker, 10)
+        _record_properties(record_property, any_server, tracker, 10)
 
-    async def test_compositor_alone(self, record_property, server) -> None:
-        server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
-        tracker = ScreencopyTracker(server.display_name)
-        async with server, tracker:
+    async def test_compositor_alone(self, record_property, any_server) -> None:
+        any_server = DisplayServer(any_server, add_extensions=ScreencopyTracker.required_extensions)
+        tracker = ScreencopyTracker(any_server.display_name)
+        async with any_server, tracker:
             await asyncio.sleep(long_wait_time)
-        _record_properties(record_property, server, tracker, 1)
+        _record_properties(record_property, any_server, tracker, 1)
 
     @pytest.mark.parametrize(
         "app",
@@ -63,12 +63,12 @@ class TestScreencopyBandwidth:
             apps.snap("mir-kiosk-kodi"),
         ],
     )
-    async def test_inactive_app(self, record_property, server, app) -> None:
-        server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
-        tracker = ScreencopyTracker(server.display_name)
-        async with server as s, tracker, s.program(app):
+    async def test_inactive_app(self, record_property, any_server, app) -> None:
+        any_server = DisplayServer(any_server, add_extensions=ScreencopyTracker.required_extensions)
+        tracker = ScreencopyTracker(any_server.display_name)
+        async with any_server as s, tracker, s.program(app):
             await asyncio.sleep(long_wait_time)
-        _record_properties(record_property, server, tracker, 2)
+        _record_properties(record_property, any_server, tracker, 2)
 
     @pytest.mark.deps(debs=("libgtk-4-dev",), pip_pkgs=(("pygobject", "gi"),))
     @pytest.mark.parametrize(

--- a/mir-ci/mir_ci/tests/test_server.py
+++ b/mir-ci/mir_ci/tests/test_server.py
@@ -4,6 +4,6 @@ from mir_ci.program.display_server import DisplayServer
 
 class TestServerCanRun:
     @pytest.mark.smoke
-    async def test_server_can_run(self, server) -> None:
-        async with DisplayServer(server) as server:
+    async def test_server_can_run(self, any_server) -> None:
+        async with DisplayServer(any_server) as any_server:
             pass

--- a/mir-ci/mir_ci/tests/test_tests.py
+++ b/mir-ci/mir_ci/tests/test_tests.py
@@ -311,8 +311,8 @@ class TestCgroup:
 
 @pytest.mark.self
 class TestDisplayServer:
-    async def test_can_get_cgroup(self, server):
-        server_instance = DisplayServer(server)
+    async def test_can_get_cgroup(self, any_server):
+        server_instance = DisplayServer(any_server)
         async with server_instance:
             cgroup = await server_instance.get_cgroup()
             assert cgroup is not None


### PR DESCRIPTION
This adds a `ServerCap` flag to describe server capabilities and a `servers(ServerCap)` selector to aid with test parametrization.