### PR TITLE
feature: MIR_CI_SERVER environment variable to express external servers

### DIFF
--- a/mir-ci/mir_ci/conftest.py
+++ b/mir-ci/mir_ci/conftest.py
@@ -74,7 +74,7 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
         channel = "latest/stable"
         classic = False
         pip_pkgs = ()
-        app_type = "snap"
+        app_type = app.AppType.snap
     else:
         raise TypeError("Bad value for argument `spec`: " + repr(spec))
 

--- a/mir-ci/mir_ci/fixtures/__init__.py
+++ b/mir-ci/mir_ci/fixtures/__init__.py
@@ -38,16 +38,16 @@ def _dependency(
 
 
 def snap(snap: str, *args: str, cmd: Collection[str] = (), id=None, **kwargs):
-    return _dependency(cmd=cmd or (snap, *args), app_type="snap", snap=snap, id=id or snap, **kwargs)
+    return _dependency(cmd=cmd or (snap, *args), app_type=AppType.snap, snap=snap, id=id or snap, **kwargs)
 
 
 def deb(
     deb: str, *args: str, cmd: Collection[str] = (), debs: Collection[str] = (), id: Optional[str] = None, **kwargs
 ):
-    return _dependency(cmd=cmd or (deb, *args), app_type="deb", debs=debs or (deb,), id=id or deb, **kwargs)
+    return _dependency(cmd=cmd or (deb, *args), app_type=AppType.deb, debs=debs or (deb,), id=id or deb, **kwargs)
 
 
 def pip(pkg: str, *args: str, cmd: Collection[str] = (), id: Optional[str] = None, **kwargs):
     return _dependency(
-        pip_pkgs=(pkg,), app_type="pip", cmd=cmd or ("python3", "-m", pkg, *args), id=id or pkg, **kwargs
+        pip_pkgs=(pkg,), app_type=AppType.pip, cmd=cmd or ("python3", "-m", pkg, *args), id=id or pkg, **kwargs
     )

--- a/mir-ci/mir_ci/fixtures/servers.py
+++ b/mir-ci/mir_ci/fixtures/servers.py
@@ -1,5 +1,5 @@
-import logging
 import os
+import warnings
 from collections.abc import Generator
 from enum import Flag, auto
 from typing import Any, Callable, Mapping, Sequence
@@ -9,9 +9,6 @@ from ..program.display_server import DisplayServer
 from . import deb, pip, snap
 
 Server = Callable[[], app.App]
-
-
-_logger = logging.getLogger(__name__)
 
 
 class ServerCap(Flag):
@@ -97,7 +94,7 @@ def _mir_ci_server():
     _MIN_SPLIT_PARTS = 3
     split = mir_ci_server.split(":")
     if len(split) < _MIN_SPLIT_PARTS:
-        _logger.error(f"Too few parts for MIR_CI_SERVER specification: {mir_ci_server}")
+        warnings.warn(f"Too few parts for MIR_CI_SERVER specification: {mir_ci_server}")
         return
 
     try:
@@ -107,7 +104,7 @@ def _mir_ci_server():
             f"Invalid app type in MIR_CI_SERVER specification: {mir_ci_server}."
             f"Expected 'snap', 'deb' or 'pip' but got {split[0]}"
         )
-        _logger.error(error_msg)
+        warnings.warn(error_msg)
         return
 
     server_command: str = split[1]
@@ -116,7 +113,7 @@ def _mir_ci_server():
         try:
             capability = capability | ServerCap[capability_str]
         except KeyError:
-            _logger.error(f"Capability is invalid in MIR_CI_SERVER: {app_type}")
+            warnings.warn(f"Capability is invalid in MIR_CI_SERVER: {app_type}")
             return
 
     if app_type == app.AppType.snap:

--- a/mir-ci/mir_ci/program/app.py
+++ b/mir-ci/mir_ci/program/app.py
@@ -1,6 +1,11 @@
-from typing import Collection, Literal, Optional
+from enum import Enum
+from typing import Collection, Optional
 
-AppType = Literal["snap", "deb", "pip"]
+
+class AppType(Enum):
+    snap = 0
+    deb = 1
+    pip = 2
 
 
 class App:

--- a/mir-ci/mir_ci/program/program.py
+++ b/mir-ci/mir_ci/program/program.py
@@ -8,6 +8,7 @@ from typing import Awaitable, Dict, List, Optional, Tuple, Union
 
 from mir_ci.interfaces.benchmarkable import Benchmarkable
 from mir_ci.lib.cgroups import Cgroup
+from mir_ci.program.app import AppType
 
 from .app import App
 
@@ -103,7 +104,7 @@ class Program(Benchmarkable):
 
     async def __aenter__(self) -> "Program":
         command = tuple(str(arg) for arg in self.command)
-        if self.app_type != "snap":
+        if self.app_type != AppType.snap:
             scope = f"mirci-{uuid.uuid4()}.scope"
             prefix = ("systemd-run", "--user", "--quiet", "--scope", f"--unit={scope}")
             command = (*prefix, *command)

--- a/mir-ci/mir_ci/pytest.ini
+++ b/mir-ci/mir_ci/pytest.ini
@@ -13,3 +13,6 @@ asyncio_mode=auto
 log_cli = True
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
+filterwarnings =
+    error
+    ignore::pytest.PytestUnraisableExceptionWarning

--- a/mir-ci/mir_ci/tests/test_tests.py
+++ b/mir-ci/mir_ci/tests/test_tests.py
@@ -11,7 +11,7 @@ import pytest
 from mir_ci.fixtures.servers import ServerCap, _mir_ci_server, servers
 from mir_ci.lib.benchmarker import Benchmarker, CgroupsBackend
 from mir_ci.lib.cgroups import Cgroup
-from mir_ci.program.app import App
+from mir_ci.program.app import App, AppType
 from mir_ci.program.display_server import DisplayServer
 from mir_ci.program.program import Program
 from mir_ci.wayland.output_watcher import OutputWatcher
@@ -64,14 +64,14 @@ class TestProgram:
     @patch("uuid.uuid4")
     async def test_program_runs_with_systemd_when_flag_is_set(self, mock_uuid) -> None:
         mock_uuid.return_value = "12345"
-        p = Program(App(["sh", "-c", "sleep 1"], "deb"))
+        p = Program(App(["sh", "-c", "sleep 1"], AppType.deb))
         async with p:
             await asyncio.sleep(0.5)
             await p.kill(2)
         mock_uuid.assert_called_once()
 
     async def test_program_can_get_cgroup(self) -> None:
-        p = Program(App(["sh", "-c", "sleep 100"], "deb"))
+        p = Program(App(["sh", "-c", "sleep 100"], AppType.deb))
         async with p:
             cgroup = await p.get_cgroup()
             assert cgroup is not None
@@ -83,7 +83,7 @@ class TestProgram:
         mock_path.return_value.exists.return_value = False
         mock_create.side_effect = FileNotFoundError
 
-        p = Program(App(["sh", "-c", "sleep 100"], "deb"))
+        p = Program(App(["sh", "-c", "sleep 100"], AppType.deb))
         async with p:
             await p.kill(2)
 
@@ -91,7 +91,7 @@ class TestProgram:
     async def test_get_cgroup_asserts_without_cgroupv2(self, mock_path) -> None:
         mock_path.return_value.exists.return_value = False
 
-        p = Program(App(["sh", "-c", "sleep 100"], "deb"))
+        p = Program(App(["sh", "-c", "sleep 100"], AppType.deb))
         with pytest.raises(AssertionError, match="Cgroup task is None, is cgroupv2 supported?"):
             async with p:
                 await p.get_cgroup()
@@ -351,24 +351,24 @@ class TestOutputWatcher:
 
 @pytest.mark.self
 class TestServers:
-    def is_server(self, server, app_type: str):
-        return server[2] == f"my-pretend-{app_type}"
+    def is_server(self, server, app_type: AppType):
+        return server[2] == f"my-pretend-{app_type.name}"
 
-    @pytest.mark.parametrize("app_type", ["snap", "deb", "pip"])
-    def test_can_parse_mir_ci_server(self, monkeypatch, app_type) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type}:my-pretend-{app_type}:ALL")
+    @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
+    def test_can_parse_mir_ci_server(self, monkeypatch, app_type: AppType) -> None:
+        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:ALL")
         server = _mir_ci_server()
         app = server[1]()[0][0]
         assert server is not None
-        if app_type == "pip":
-            assert app.command == ("python3", "-m", f"my-pretend-{app_type}")
+        if app_type == AppType.pip:
+            assert app.command == ("python3", "-m", f"my-pretend-{app_type.name}")
         else:
-            assert app.command == (f"my-pretend-{app_type}",)
+            assert app.command == (f"my-pretend-{app_type.name}",)
         assert app.app_type == app_type
 
-    @pytest.mark.parametrize("app_type", ["snap", "deb", "pip"])
-    def test_mir_ci_server_string_missing_capabilities(self, monkeypatch, app_type) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type}:my-pretend-{app_type}")
+    @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
+    def test_mir_ci_server_string_missing_capabilities(self, monkeypatch, app_type: AppType) -> None:
+        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}")
         server = _mir_ci_server()
         assert server is None
 
@@ -377,19 +377,19 @@ class TestServers:
         server = _mir_ci_server()
         assert server is None
 
-    @pytest.mark.parametrize("app_type", ["snap", "deb", "pip"])
-    def test_mir_ci_server_string_capability_is_invalid(self, monkeypatch, app_type) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type}:my-pretend-{app_type}:INVALID")
+    @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
+    def test_mir_ci_server_string_capability_is_invalid(self, monkeypatch, app_type: AppType) -> None:
+        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:INVALID")
         server = _mir_ci_server()
         assert server is None
 
-    @pytest.mark.parametrize("app_type", ["snap", "deb", "pip"])
-    def test_mir_ci_server_is_present_in_server_list(self, monkeypatch, app_type) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type}:my-pretend-{app_type}:ALL")
+    @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
+    def test_mir_ci_server_is_present_in_server_list(self, monkeypatch, app_type: AppType) -> None:
+        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:ALL")
         matches = next((server for server in servers() if self.is_server(server, app_type)), None)
         assert matches is not None
 
-    @pytest.mark.parametrize("app_type", ["snap", "deb", "pip"])
+    @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
     @pytest.mark.parametrize(
         "capabilities",
         [
@@ -399,7 +399,7 @@ class TestServers:
         ],
     )
     def test_mir_ci_server_can_be_found_by_capability(self, monkeypatch, app_type, capabilities: list[str]) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type}:my-pretend-{app_type}:{':'.join(capabilities)}")
+        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:{':'.join(capabilities)}")
         capability = ServerCap.NONE
         for capability_str in capabilities:
             capability = capability & ServerCap[capability_str]
@@ -407,9 +407,9 @@ class TestServers:
         matches = next((server for server in servers(capability) if self.is_server(server, app_type)), None)
         assert matches is not None
 
-    @pytest.mark.parametrize("app_type", ["snap", "deb", "pip"])
+    @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
     def test_mir_ci_server_cannot_be_found_if_it_lacks_capability(self, monkeypatch, app_type) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type}:my-pretend-{app_type}:FLOATING_WINDOWS:SCREENCOPY")
+        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:FLOATING_WINDOWS:SCREENCOPY")
         matches = next(
             (server for server in servers(ServerCap.DISPLAY_CONFIG) if self.is_server(server, app_type)), None
         )

--- a/mir-ci/mir_ci/tests/test_tests.py
+++ b/mir-ci/mir_ci/tests/test_tests.py
@@ -220,7 +220,7 @@ class TestCGroupsBackend:
         cgb = CgroupsBackend()
         cgb.add("pi", pi)
 
-        with pytest.warns(UserWarning, match="Ignoring cgroup read failure: read error"):
+        with pytest.raises(UserWarning, match="Ignoring cgroup read failure: read error"):
             await cgb.poll()
 
     @pytest.mark.filterwarnings("error")
@@ -368,20 +368,20 @@ class TestServers:
 
     @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
     def test_mir_ci_server_string_missing_capabilities(self, monkeypatch, app_type: AppType) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}")
-        server = _mir_ci_server()
-        assert server is None
+        with pytest.raises(UserWarning):
+            monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}")
+            _mir_ci_server()
 
     def test_mir_ci_server_string_app_type_is_invalid(self, monkeypatch) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", "invalid:my-pretend-invalid:ALL")
-        server = _mir_ci_server()
-        assert server is None
+        with pytest.raises(UserWarning):
+            monkeypatch.setenv("MIR_CI_SERVER", "invalid:my-pretend-invalid:ALL")
+            _mir_ci_server()
 
     @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
     def test_mir_ci_server_string_capability_is_invalid(self, monkeypatch, app_type: AppType) -> None:
-        monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:INVALID")
-        server = _mir_ci_server()
-        assert server is None
+        with pytest.raises(UserWarning):
+            monkeypatch.setenv("MIR_CI_SERVER", f"{app_type.name}:my-pretend-{app_type.name}:INVALID")
+            _mir_ci_server()
 
     @pytest.mark.parametrize("app_type", [AppType.snap, AppType.deb, AppType.pip])
     def test_mir_ci_server_is_present_in_server_list(self, monkeypatch, app_type: AppType) -> None:


### PR DESCRIPTION
## What's new?
- We can now specify a `MIR_CI_SERVER` and the specified server will be included in our runs

## How to test
```sh
MIR_CI_SERVER=snap:<SOME_OTHER_MIR_BASED_SHELL>:ALL pytest -k <SOME_OTHER_MIR_BASED_SHELL>
```