### PR TITLE
robot: add `--robot-log` option

### DIFF
--- a/mir-ci/mir_ci/conftest.py
+++ b/mir-ci/mir_ci/conftest.py
@@ -22,6 +22,7 @@ DEP_FIXTURES = {"any_server", "deps"}  # these are all the fixtures changing the
 
 def pytest_addoption(parser):
     parser.addoption("--deps", help="Only install the test dependencies", action="store_true")
+    parser.addoption("--robot-log", help="Location of the Robot log file", type=pathlib.Path)
 
 
 def _find_pips(pips):
@@ -241,3 +242,8 @@ def env(request: pytest.FixtureRequest) -> Generator:
             for var, value in mark.kwargs.items():
                 m.setenv(var, value)
         yield
+
+
+@pytest.fixture(scope="session")
+def robot_log(request: pytest.FixtureRequest) -> pathlib.Path:
+    return request.config.getoption("--robot-log") or pathlib.Path("log.html")

--- a/mir-ci/mir_ci/tests/test_drag_and_drop.py
+++ b/mir-ci/mir_ci/tests/test_drag_and_drop.py
@@ -75,7 +75,7 @@ class TestDragAndDrop:
             ("python3", APP_PATH, "--source", "text", "--target", "text", "--expect", "text"),
         ],
     )
-    async def test_source_and_dest_match(self, server, app, tmp_path) -> None:
+    async def test_source_and_dest_match(self, robot_log, server, app, tmp_path) -> None:
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions
         server_instance = DisplayServer(server, add_extensions=extensions)
         program = server_instance.program(App(app))
@@ -94,7 +94,7 @@ class TestDragAndDrop:
             robot_file.write(
                 ROBOT_TEMPLATE.format(settings=ROBOT_SETTINGS, variables=ROBOT_VARIABLES, test_case=robot_test_case)
             )
-            robot = server_instance.program(App(("robot", "-d", tmp_path, robot_file.name)))
+            robot = server_instance.program(App(("robot", "-d", tmp_path, "--log", robot_log, robot_file.name)))
 
             async with server_instance, program, robot:
                 await robot.wait(60)
@@ -109,7 +109,7 @@ class TestDragAndDrop:
             ("python3", "-u", APP_PATH, "--source", "text", "--target", "pixbuf", "--expect", "pixbuf"),
         ],
     )
-    async def test_source_and_dest_mismatch(self, server, app, tmp_path) -> None:
+    async def test_source_and_dest_mismatch(self, robot_log, server, app, tmp_path) -> None:
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions
         server_instance = DisplayServer(server, add_extensions=extensions)
         program = server_instance.program(App(app))
@@ -129,7 +129,7 @@ class TestDragAndDrop:
             robot_file.write(
                 ROBOT_TEMPLATE.format(settings=ROBOT_SETTINGS, variables=ROBOT_VARIABLES, test_case=robot_test_case)
             )
-            robot = server_instance.program(App(("robot", "-d", tmp_path, robot_file.name)))
+            robot = server_instance.program(App(("robot", "-d", tmp_path, "--log", robot_log, robot_file.name)))
 
             async with server_instance, program, robot:
                 await robot.wait(60)

--- a/mir-ci/mir_ci/tests/test_osk.py
+++ b/mir-ci/mir_ci/tests/test_osk.py
@@ -84,7 +84,7 @@ def collect_assets(platform: str, resources: Collection[str], suite: str, varian
 @pytest.mark.parametrize("osk", (apps.ubuntu_frame_osk(),))
 @pytest.mark.parametrize("app", (apps.pluma(),))
 class TestOSK:
-    async def test_osk_typing(self, platform, server, osk, app, tmp_path):
+    async def test_osk_typing(self, robot_log, platform, server, osk, app, tmp_path):
         extensions = VirtualPointer.required_extensions + ScreencopyTracker.required_extensions + osk.extensions
         server_instance = DisplayServer(
             server,
@@ -95,7 +95,7 @@ class TestOSK:
         async with server_instance, server_instance.program(app) as app, server_instance.program(osk) as osk:
             if platform == "wayland":
                 tuple((tmp_path / k).symlink_to(v) for k, v in assets.items())
-                robot = server_instance.program(App(("robot", "-d", tmp_path, tmp_path)))
+                robot = server_instance.program(App(("robot", "-d", tmp_path, "--log", robot_log, tmp_path)))
                 async with robot:
                     await robot.wait(120)
 
@@ -114,7 +114,7 @@ class TestOSK:
 
                 status, log = proxy.zapper_run(os.environ["ZAPPER_HOST"], "robot_run", procedure, asset_map, {})
 
-                with open(tmp_path / "log.html", "w") as f:
+                with open(robot_log.is_absolute() and robot_log or (tmp_path / robot_log), "w") as f:
                     f.write(log)
 
                 if not status:


### PR DESCRIPTION
If absolute, it's only useful when you run one test at a time (like we do with checkbox).