### PR TITLE
Fix checking against frame_count in Screencopy.match

### DIFF
--- a/mir-ci/mir_ci/tests/robot/platforms/wayland/Screencopy.py
+++ b/mir-ci/mir_ci/tests/robot/platforms/wayland/Screencopy.py
@@ -50,9 +50,9 @@ class Screencopy(ScreencopyTracker):
         last_checked_frame_count = 0
         screenshot = None
         while time.time() <= end_time:
-            screenshot = await asyncio.wait_for(self.grab_screenshot(), timeout)
-            if last_checked_frame_count != self.frame_count:
-                last_checked_frame_count = self.frame_count
+            frame_count, screenshot = await asyncio.wait_for(self.grab_screenshot(), timeout)
+            if last_checked_frame_count != frame_count:
+                last_checked_frame_count = frame_count
                 try:
                     regions = self._rpa_images.find_template_in_image(
                         screenshot,
@@ -82,7 +82,7 @@ class Screencopy(ScreencopyTracker):
         """
         Grabs the current frame tracked by the screencopy tracker.
 
-        :return Pillow Image of the frame
+        :return Tuple (frame count, Pillow Image of the frame)
         """
         await self.connect()
 
@@ -100,7 +100,7 @@ class Screencopy(ScreencopyTracker):
         b, g, r, a, *_ = image.split()
         image = Image.merge("RGBA", (r, g, b, a))
 
-        return image
+        return (self.frame_count, image)
 
     async def connect(self):
         """Connect to the display."""


### PR DESCRIPTION
`self.frame_count` accessed in `match()` could contain a frame number that is out of sync with the grabbed screenshot. This fix makes sure that the frame count checked in `match()` is the actual frame count when `grab_screenshot()` is called.