### PR TITLE
snaps: switch over to `base: core24`

### DIFF
--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -43,7 +43,6 @@ SNAPS = {
     },
     "mir-kiosk": {
         "beta": {"ppa": "rc", "recipe": "mir-kiosk-beta", "release": "focal"},
-        "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge", "release": "focal"},
     },
     "mir-kiosk-kodi": {
         "edge": {"recipe": "mir-kiosk-kodi-edge", "non-uniform": True},
@@ -56,9 +55,7 @@ SNAPS = {
     },
     "mir-test-tools": {
         "20/beta": {"ppa": "rc", "recipe": "mir-test-tools-20-beta", "release": "focal"},
-        "20/edge": {"ppa": "dev", "recipe": "mir-test-tools-20-edge", "release": "focal"},
         "22/beta": {"ppa": "rc", "recipe": "mir-test-tools-22-beta", "release": "jammy"},
-        "22/edge": {"ppa": "dev", "recipe": "mir-test-tools-22-edge", "release": "jammy"},
         "24/beta": {"ppa": "rc", "recipe": "mir-test-tools-24-beta"},
         "24/edge": {"ppa": "dev", "recipe": "mir-test-tools-24-edge"},
     },
@@ -68,9 +65,7 @@ SNAPS = {
     },
     "ubuntu-frame": {
         "20/beta": {"ppa": "rc", "recipe": "ubuntu-frame-20-beta", "release": "focal"},
-        "20/edge": {"ppa": "dev", "recipe": "ubuntu-frame-20-edge", "release": "focal"},
-        "22/beta": {"ppa": "rc", "recipe": "ubuntu-frame-22-edge", "release": "jammy"},
-        "22/edge": {"ppa": "dev", "recipe": "ubuntu-frame-22-edge", "release": "jammy"},
+        "22/beta": {"ppa": "rc", "recipe": "ubuntu-frame-22-beta", "release": "jammy"},
         "24/beta": {"ppa": "rc", "recipe": "ubuntu-frame-24-beta"},
         "24/edge": {"ppa": "dev", "recipe": "ubuntu-frame-24-edge"},
     },

--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -25,7 +25,7 @@ logger.setLevel(logging.DEBUG)
 
 APPLICATION = "mir-ci"
 LAUNCHPAD = "production"
-DEFAULT_RELEASE = "jammy"
+DEFAULT_RELEASE = "noble"
 TEAM = "mir-team"
 SOURCE_NAME = "mir"
 
@@ -35,16 +35,15 @@ SNAPS = {
     },
     "confined-shell": {
         "edge": {"recipe": "confined-shell-edge"},
-        "edge/24": {"ppa": "dev", "recipe": "confined-shell-edge-24", "release": "noble", "check-usns": False},
     },
     "graphics-test-tools": {
         "20/beta": {"recipe": "graphics-test-tools-20-beta"},
         "22/beta": {"recipe": "graphics-test-tools-22-beta"},
-        "24/edge": {"recipe": "graphics-test-tools-24-edge", "check-usns": False},
+        "24/edge": {"recipe": "graphics-test-tools-24-edge"},
     },
     "mir-kiosk": {
-        "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge", "release": "focal"},
         "beta": {"ppa": "rc", "recipe": "mir-kiosk-beta", "release": "focal"},
+        "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge", "release": "focal"},
     },
     "mir-kiosk-kodi": {
         "edge": {"recipe": "mir-kiosk-kodi-edge", "non-uniform": True},
@@ -56,35 +55,36 @@ SNAPS = {
         "edge": {"recipe": "mir-kiosk-scummvm-edge"},
     },
     "mir-test-tools": {
-        "20/edge": {"ppa": "dev", "recipe": "mir-test-tools-20-edge", "release": "focal"},
         "20/beta": {"ppa": "rc", "recipe": "mir-test-tools-20-beta", "release": "focal"},
-        "22/edge": {"ppa": "dev", "recipe": "mir-test-tools-22-edge"},
-        "22/beta": {"ppa": "rc", "recipe": "mir-test-tools-22-beta"},
-        "24/edge": {"ppa": "dev", "recipe": "mir-test-tools-24-edge", "release": "noble", "check-usns": False},
+        "20/edge": {"ppa": "dev", "recipe": "mir-test-tools-20-edge", "release": "focal"},
+        "22/beta": {"ppa": "rc", "recipe": "mir-test-tools-22-beta", "release": "jammy"},
+        "22/edge": {"ppa": "dev", "recipe": "mir-test-tools-22-edge", "release": "jammy"},
+        "24/beta": {"ppa": "rc", "recipe": "mir-test-tools-24-beta"},
+        "24/edge": {"ppa": "dev", "recipe": "mir-test-tools-24-edge"},
     },
     "miriway": {
-        "edge": {"ppa": "dev", "recipe": "miriway-edge"},
         "beta": {"ppa": "rc", "recipe": "miriway-beta"},
-        "edge/24": {"ppa": "dev", "recipe": "miriway-edge-24", "release": "noble", "check-usns": False},
+        "edge": {"ppa": "dev", "recipe": "miriway-edge"},
     },
     "ubuntu-frame": {
-        "20/edge": {"ppa": "dev", "recipe": "ubuntu-frame-20-edge", "release": "focal"},
         "20/beta": {"ppa": "rc", "recipe": "ubuntu-frame-20-beta", "release": "focal"},
-        "22/edge": {"ppa": "dev", "recipe": "ubuntu-frame-22-edge"},
-        "22/beta": {"ppa": "rc", "recipe": "ubuntu-frame-22-beta"},
-        "24/edge": {"ppa": "dev", "recipe": "ubuntu-frame-24-edge", "release": "noble", "check-usns": False},
+        "20/edge": {"ppa": "dev", "recipe": "ubuntu-frame-20-edge", "release": "focal"},
+        "22/beta": {"ppa": "rc", "recipe": "ubuntu-frame-22-edge", "release": "jammy"},
+        "22/edge": {"ppa": "dev", "recipe": "ubuntu-frame-22-edge", "release": "jammy"},
+        "24/beta": {"ppa": "rc", "recipe": "ubuntu-frame-24-beta"},
+        "24/edge": {"ppa": "dev", "recipe": "ubuntu-frame-24-edge"},
     },
     "ubuntu-frame-osk": {
         "20/beta": {"recipe": "ubuntu-frame-osk-20-beta"},
-        "22/edge": {"recipe": "ubuntu-frame-osk-22-edge"},
         "22/beta": {"recipe": "ubuntu-frame-osk-22-beta"},
-        "24/beta": {"recipe": "ubuntu-frame-osk-24-beta", "check-usns": False},
+        "24/beta": {"recipe": "ubuntu-frame-osk-24-beta"},
+        "24/edge": {"recipe": "ubuntu-frame-osk-24-edge"},
     },
     "ubuntu-frame-vnc": {
         "20/beta": {"recipe": "ubuntu-frame-vnc-20-beta"},
-        "22/edge": {"recipe": "ubuntu-frame-vnc-22-edge"},
         "22/beta": {"recipe": "ubuntu-frame-vnc-22-beta"},
-        "24/beta": {"recipe": "ubuntu-frame-vnc-24-beta", "check-usns": False},
+        "24/beta": {"recipe": "ubuntu-frame-vnc-24-beta"},
+        "24/edge": {"recipe": "ubuntu-frame-vnc-24-edge"},
     },
     "mesa-core20": {
         "beta": {"recipe": "mesa-core20-beta"},
@@ -93,7 +93,7 @@ SNAPS = {
         "beta": {"recipe": "mesa-core22-beta"},
     },
     "mesa-2404": {
-        "edge": {"recipe": "mesa-2404-edge", "check-usns": False},
+        "beta": {"recipe": "mesa-2404-beta"},
     },
     "nvidia-core22": {
         "beta": {"recipe": "nvidia-core22-beta"},


### PR DESCRIPTION
This should only land after:
- [x] https://github.com/canonical/confined-shell-wip/pull/37
- [x] https://github.com/canonical/ubuntu-frame/pull/177
- [x] https://github.com/Miriway/Miriway/pull/94
- [x] https://github.com/canonical/ubuntu-frame-osk/pull/73
- [x] https://github.com/canonical/ubuntu-frame-vnc/pull/20
- [x] https://github.com/canonical/mir/pull/3364