### PR TITLE
bugfix: ScreencopyTracker "with..." to be async

### DIFF
--- a/mir-ci/mir_ci/wayland/screencopy_tracker.py
+++ b/mir-ci/mir_ci/wayland/screencopy_tracker.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     tracker = ScreencopyTracker(os.environ["WAYLAND_DISPLAY"])
 
     async def capture_frames():
-        with tracker:
+        async with tracker:
             await asyncio.sleep(60)
 
     try:


### PR DESCRIPTION
You would only see this if you tried to run the `ScreencopyTracker` directly, which I do :)