### PR TITLE
cgroups: fall back to parent cgroup if no child found

### DIFF
--- a/mir-ci/mir_ci/lib/cgroups.py
+++ b/mir-ci/mir_ci/lib/cgroups.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import pathlib
+import warnings
 from typing import Iterator
 
 
@@ -29,7 +30,8 @@ class Cgroup:
             if path != parent_path:
                 return path
         else:
-            raise RuntimeError(f"Unable to read cgroup directory for pid: {pid}")
+            warnings.warn(f"Unable to find child cgroup for pid: {pid}")
+            return parent_path
 
     @staticmethod
     def _get_cgroup_dir_internal(pid: int) -> pathlib.Path:

--- a/mir-ci/mir_ci/tests/test_tests.py
+++ b/mir-ci/mir_ci/tests/test_tests.py
@@ -4,6 +4,7 @@ import random
 import time
 from collections import OrderedDict
 from contextlib import suppress
+from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, Mock, call, mock_open, patch
 
@@ -308,6 +309,11 @@ class TestCgroup:
     async def test_cgroup_path_raises_runtime_error_when_contents_are_none(self, mock_open):
         with pytest.raises(RuntimeError, match=f"Unable to find path for process with pid: {os.getpid()}"):
             await Cgroup.get_cgroup_dir(12345)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="0::path")
+    async def test_group_path_warns_when_no_child_found(self, mock_open):
+        with pytest.warns(UserWarning, match="Unable to find child cgroup"):
+            assert await Cgroup.get_cgroup_dir(12345) == Path("/sys/fs/cgroup/path")
 
 
 @pytest.mark.self


### PR DESCRIPTION
This is a change in snapd 2.65+, not all snap apps get a child cgroup any more.