### PR TITLE
Increase robot timeout to 120s in test_vnc

### DIFF
--- a/mir-ci/mir_ci/tests/test_vnc.py
+++ b/mir-ci/mir_ci/tests/test_vnc.py
@@ -62,4 +62,4 @@ class TestVnc:
 
             async with server_instance, program:
                 async with robot:
-                    await robot.wait()
+                    await robot.wait(120)


### PR DESCRIPTION
This PR gives more time for the robot process in test_vnc to complete and shutdown gracefully.