### PR TITLE
wayland: crop the timestamp so it fits in `uint`

### DIFF
--- a/mir-ci/mir_ci/wayland/wayland_client.py
+++ b/mir-ci/mir_ci/wayland/wayland_client.py
@@ -23,7 +23,8 @@ class WaylandClient:
             raise e
 
     def timestamp(self) -> int:
-        return int(time.monotonic() * 1000)
+        # ensure the value fits in a `uint_t`
+        return int(time.monotonic() * 1000) & 0xFFFFFFFF
 
     @abstractmethod
     def registry_global(self, registry, id_num: int, iface_name: str, version: int) -> None:


### PR DESCRIPTION
It's a client-local timestamp:

> timestamp with millisecond granularity; with an undefined base